### PR TITLE
fix issue with flexbox layout

### DIFF
--- a/src/Reorderable/Update.elm
+++ b/src/Reorderable/Update.elm
@@ -163,21 +163,11 @@ update msg dragInfo =
 getOverlapArea : Bounds -> Bounds -> ( Float, Bool )
 getOverlapArea d0 d1 =
     let
-        d0Width =
-            d0.right - d0.left
-
-        d1Width =
-            d1.right - d1.left
-
         xOverlap =
-            (min d0.right d1.right - max d0.left d1.left)
+            min d0.right d1.right - max d0.left d1.left
 
         yOverlap =
             min d0.bottom d1.bottom - max d0.top d1.top
-
-        halfWay =
-            ((d1Width - d0Width) * yOverlap)
-                |> max 0
 
         overlap =
             -- We need to check if both axis don't overlap.
@@ -186,22 +176,8 @@ getOverlapArea d0 d1 =
                 0
             else
                 max 0 (xOverlap * yOverlap)
-
-        overlapPlusLeft =
-            overlap
-                + ((max 0 (d0.left - d1.left)) * yOverlap)
-                |> max 0
     in
-        -- For dragging placeholders that are smaller than other items, determine destination by distance
-        if d0Width < d1Width then
-            if overlapPlusLeft >= halfWay && d0.right < d1.right then
-                ( d1Width * yOverlap, False )
-            else if overlapPlusLeft < halfWay && d0.right < d1.right && d0.left > d1.left then
-                ( 1, True )
-            else
-                ( 0, False )
-        else
-            ( overlap, False )
+    ( overlap, False )
 
 
 getMostOverlappingBounds : Bounds -> List Bounds -> Maybe ( Int, Bool )

--- a/src/Reorderable/Update.elm
+++ b/src/Reorderable/Update.elm
@@ -180,8 +180,12 @@ getOverlapArea d0 d1 =
                 |> max 0
 
         overlap =
-            (xOverlap * yOverlap)
-                |> max 0
+            -- We need to check if both axis don't overlap.
+            -- We get incorrect results without this check, because -xOverlap * -yOverlap is greater than 0.
+            if xOverlap < 0 && yOverlap < 0 then
+                0
+            else
+                max 0 (xOverlap * yOverlap)
 
         overlapPlusLeft =
             overlap


### PR DESCRIPTION
 I found an issue with flexbox-layouts, while working on a [simple example](https://github.com/stoeffel/elm-reorderable/tree/simple-example).

<details><summary>The Issue</summary>
<img src="https://user-images.githubusercontent.com/1217681/27179169-aa72338e-51cd-11e7-8d5d-e9c95767de7e.gif" />
</details>

The problem was in the calculation of the overlapping area. 
We calculate the overlap of the x and y axis. The overlap is negative if it doesn't overlap. We calculate the area by multiplying both overlaps and we get a area bigger than `0` if both numbers are negative.

<details><summary>The Fix</summary>
We don't get a `destIndex` in some cases.
<img src="https://user-images.githubusercontent.com/1217681/27179253-075f1512-51ce-11e7-90b6-d9aa2ae12333.gif" />

</details>
<hr>




I stumbled over an other issue with small placeholders that is in the same function. I hope you don't mind that I fix both things in one PR.

<details><summary>The Issue</summary>
<img src="https://user-images.githubusercontent.com/1217681/27180327-392cc148-51d3-11e7-96ed-eceba0d51ba3.gif" />

</details>
I'm pretty sure that we don't need the extra logic for small placeholders. The calculation of the overlap should work in all cases.
<details><summary>The Fix</summary>
<img src="https://user-images.githubusercontent.com/1217681/27180330-3d36a3a8-51d3-11e7-8ed1-37bd1b072f22.gif" />


</details>